### PR TITLE
Fix broken install

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Find the quantiles of `values` to within alpha relative error.
 ```
 quantiles = [sketch.quantile(q) for q in [0.5, 0.75, 0.9, 1]]
 ```
-Merge another `DogSketch` into `sketch`.
+Merge another `DDSketch` into `sketch`.
 ```
 another_sketch = DDSketch()
 other_values = np.random.normal(size=500)
@@ -67,7 +67,7 @@ for v in other_values:
   another_sketch.add(v)
 sketch.merge(another_sketch)
 ```
-The quantiles of `values` concatenated with `other_values` are still accurate to within alpha relative error.ls
+The quantiles of `values` concatenated with `other_values` are still accurate to within alpha relative error.
 
 ## References
 [1] Michael B. Greenwald and Sanjeev Khanna. Space-efficient online computation of quantile summaries. In Proc. 2001 ACM

--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -47,7 +47,7 @@ class DDSketch(object):
 
     @property
     def name(self):
-        return 'DogSketch'
+        return 'DDSketch'
 
     @property
     def num_values(self):
@@ -106,7 +106,7 @@ class DDSketch(object):
             
     def merge(self, sketch):
         if not self.mergeable(sketch):
-            raise UnequalSketchParametersException("Cannot merge two DogSketches with different parameters")
+            raise UnequalSketchParametersException("Cannot merge two DDSketches with different parameters")
 
         if sketch._count == 0:
             return

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='Jee Rim, Charles-Philippe Masson',
     author_email='jee.rim@datadoghq.com charles.masson@datadoghq.com',
     license='BSD-3-Clause',
-    packages=['dogsketch', 'gkarray'],
+    packages=['ddsketch', 'gkarray'],
     install_requires=[
         'numpy>=1.11.0'
     ],


### PR DESCRIPTION
### What does this PR do?

This PR updates out of date references to `DogSketch` to `DDSketch`, allowing this repository to be installed from git as described in the README. Currently, installation from git is broken as explicit references to `DogSketch` are made in `setup.py`.

### Motivation

So that I can install ddsketch to play with it locally.

### Additional Notes

N/A
