### PR TITLE
move protobuf specific funcs to pb

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains python implementations of the distributed quantile sketch alg
 
 ## Installation
 
-To install this package, clone the repo and run `python setup.py install`. This package depends on `numpy` and `protobuf`.
+To install this package, clone the repo and run `python setup.py install`. This package depends on `numpy` and `protobuf`. (The protobuf dependency can be removed if it's not applicable.)
 
 ## GKArray
 

--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -37,9 +37,8 @@ DDSketch implementations are also available in:
 
 import numpy as np
 
-import ddsketch.pb.ddsketch_pb2 as pb
 from .exception import IllegalArgumentException, UnequalSketchParametersException
-from .mapping import KeyMapping, LogarithmicMapping
+from .mapping import LogarithmicMapping
 from .store import CollapsingHighestDenseStore, CollapsingLowestDenseStore, DenseStore
 
 
@@ -199,32 +198,6 @@ class BaseDDSketch:
         self.max = sketch.max
         self.count = sketch.count
         self._sum = sketch.sum
-
-    def to_proto(self):
-        """serialize to protobuf"""
-        return pb.DDSketch(
-            mapping=self.mapping.to_proto(),
-            positiveValues=self.store.to_proto(),
-            negativeValues=self.negative_store.to_proto(),
-            zeroCount=self.zero_count,
-        )
-
-    @classmethod
-    def from_proto(cls, proto):
-        """deserialize from protobuf
-
-        N.B., The current protobuf loses any min/max/sum/avg information.
-        """
-        mapping = KeyMapping.from_proto(proto.mapping)
-        negative_store = DenseStore.from_proto(proto.negativeValues)
-        store = DenseStore.from_proto(proto.positiveValues)
-        zero_count = proto.zeroCount
-        return BaseDDSketch(
-            mapping=mapping,
-            store=store,
-            negative_store=negative_store,
-            zero_count=zero_count,
-        )
 
 
 class DDSketch(BaseDDSketch):

--- a/ddsketch/pb/proto.py
+++ b/ddsketch/pb/proto.py
@@ -1,0 +1,97 @@
+from ..ddsketch import BaseDDSketch
+from ..exception import IllegalArgumentException
+from ..mapping import (
+    CubicallyInterpolatedMapping,
+    LinearlyInterpolatedMapping,
+    LogarithmicMapping,
+)
+from ..store import DenseStore
+
+import ddsketch.pb.ddsketch_pb2 as pb
+
+
+class KeyMappingProto:
+    @classmethod
+    def _proto_interpolation(cls, mapping):
+        if type(mapping) is LogarithmicMapping:
+            return pb.IndexMapping.Interpolation.NONE
+        if type(mapping) is LinearlyInterpolatedMapping:
+            return pb.IndexMapping.Interpolation.LINEAR
+        if type(mapping) is CubicallyInterpolatedMapping:
+            return pb.IndexMapping.Interpolation.CUBIC
+
+    @classmethod
+    def to_proto(cls, mapping):
+        """serialize to protobuf"""
+        return pb.IndexMapping(
+            gamma=mapping.gamma,
+            indexOffset=mapping._offset,
+            interpolation=cls._proto_interpolation(mapping),
+        )
+
+    @classmethod
+    def from_proto(cls, proto):
+        """deserialize from protobuf"""
+        if proto.interpolation == pb.IndexMapping.Interpolation.NONE:
+            return LogarithmicMapping.from_gamma_offset(proto.gamma, proto.indexOffset)
+        elif proto.interpolation == pb.IndexMapping.Interpolation.LINEAR:
+            return LinearlyInterpolatedMapping.from_gamma_offset(
+                proto.gamma, proto.indexOffset
+            )
+        elif proto.interpolation == pb.IndexMapping.Interpolation.CUBIC:
+            return CubicallyInterpolatedMapping.from_gamma_offset(
+                proto.gamma, proto.indexOffset
+            )
+        else:
+            raise IllegalArgumentException("unrecognized interpolation")
+
+
+class StoreProto():
+    """Currently only supports DenseStore"""
+
+    @classmethod
+    def to_proto(cls, store):
+        """serialize to protobuf"""
+        return pb.Store(
+            contiguousBinCounts=store.bins, contiguousBinIndexOffset=store.offset
+        )
+
+    @classmethod
+    def from_proto(cls, proto):
+        """deserialize from protobuf"""
+        store = DenseStore()
+        index = proto.contiguousBinIndexOffset
+        store.offset = index
+        for count in proto.contiguousBinCounts:
+            store.add(index, count)
+            index += 1
+        return store
+
+
+class DDSketchProto:
+    @classmethod
+    def to_proto(self, ddsketch):
+        """serialize to protobuf"""
+        return pb.DDSketch(
+            mapping=KeyMappingProto.to_proto(ddsketch.mapping),
+            positiveValues=StoreProto.to_proto(ddsketch.store),
+            negativeValues=StoreProto.to_proto(ddsketch.negative_store),
+            zeroCount=ddsketch.zero_count,
+        )
+
+    @classmethod
+    def from_proto(cls, proto):
+        """deserialize from protobuf
+
+        N.B., The current protobuf loses any min/max/sum/avg information.
+        """
+        mapping = KeyMappingProto.from_proto(proto.mapping)
+        negative_store = StoreProto.from_proto(proto.negativeValues)
+        store = StoreProto.from_proto(proto.positiveValues)
+        zero_count = proto.zeroCount
+        return BaseDDSketch(
+            mapping=mapping,
+            store=store,
+            negative_store=negative_store,
+            zero_count=zero_count,
+        )

--- a/ddsketch/pb/tests/test_proto.py
+++ b/ddsketch/pb/tests/test_proto.py
@@ -1,0 +1,83 @@
+from abc import ABC
+from unittest import TestCase
+
+from ddsketch.mapping import (
+    CubicallyInterpolatedMapping,
+    LogarithmicMapping,
+    LinearlyInterpolatedMapping,
+)
+from ddsketch.pb.proto import DDSketchProto, KeyMappingProto, StoreProto
+from ddsketch.store import DenseStore
+from ddsketch.tests.test_ddsketch import TestDDSketch
+from ddsketch.tests.test_store import TestDenseStore
+
+
+class TestKeyMappingProto(ABC):
+    offsets = [0, 1, -12.23, 7768.3]
+
+    def test_round_trip(self):
+        rel_accs = [1e-1, 1e-2, 1e-8]
+        for rel_acc in rel_accs:
+            for offset in self.offsets:
+                mapping = self.mapping(rel_acc, offset)
+                round_trip_mapping = KeyMappingProto.from_proto(
+                    KeyMappingProto.to_proto(mapping)
+                )
+                self.assertEqual(type(mapping), type(round_trip_mapping))
+                self.assertAlmostEqual(
+                    mapping.relative_accuracy, round_trip_mapping.relative_accuracy
+                )
+                self.assertAlmostEqual(mapping.value(0), round_trip_mapping.value(0))
+
+
+class TestLogarithmicMapping(TestKeyMappingProto, TestCase):
+    """Class for testing LogarithmicMapping class"""
+
+    def mapping(self, relative_accuracy, offset):
+        return LogarithmicMapping(relative_accuracy, offset)
+
+
+class TestLinearlyInterpolatedMapping(TestKeyMappingProto, TestCase):
+    """Class for testing LinearlyInterpolatedMapping class"""
+
+    def mapping(self, relative_accuracy, offset):
+        return LinearlyInterpolatedMapping(relative_accuracy, offset)
+
+
+class TestCubicallyInterpolatedMapping(TestKeyMappingProto, TestCase):
+    """Class for testing CubicallyInterpolatedMapping class"""
+
+    def mapping(self, relative_accuracy, offset):
+        return CubicallyInterpolatedMapping(relative_accuracy, offset)
+
+
+class TestStoreProto(TestDenseStore, TestCase):
+    def _test_store(self, values):
+        store = DenseStore()
+        for val in values:
+            store.add(val)
+        self._test_values(StoreProto.from_proto(StoreProto.to_proto(store)), values)
+
+
+class TestDDSketchProto(TestDDSketch, TestCase):
+    def _evaluate_sketch_accuracy(self, sketch, data, eps, summary_stats=False):
+        round_trip_sketch = DDSketchProto.from_proto(DDSketchProto.to_proto(sketch))
+        super()._evaluate_sketch_accuracy(round_trip_sketch, data, eps, summary_stats)
+
+    def test_add_multiple(self):
+        """Override."""
+
+    def test_add_decimal(self):
+        """Override."""
+
+    def test_merge_equal(self):
+        """Override."""
+
+    def test_merge_unequal(self):
+        """Override."""
+
+    def test_merge_mixed(self):
+        """Override."""
+
+    def test_consistent_merge(self):
+        """Override."""

--- a/ddsketch/store.py
+++ b/ddsketch/store.py
@@ -10,8 +10,6 @@ otherwise."""
 from abc import ABC, abstractmethod
 import math
 
-import ddsketch.pb.ddsketch_pb2 as pb
-
 
 CHUNK_SIZE = 128
 
@@ -63,15 +61,6 @@ class Store(ABC):
         """Merge another store into this one. This should be equivalent as running the
         add operations that have *been run on the other store on this one.
         """
-
-    @abstractmethod
-    def to_proto(self):
-        """serialize to protobuf"""
-
-    @classmethod
-    @abstractmethod
-    def from_proto(cls, proto):
-        """deserialize from protobuf"""
 
 
 class DenseStore(Store):
@@ -206,21 +195,6 @@ class DenseStore(Store):
             self.bins[key - self.offset] += store.bins[key - store.offset]
 
         self.count += store.count
-
-    def to_proto(self):
-        return pb.Store(
-            contiguousBinCounts=self.bins, contiguousBinIndexOffset=self.offset
-        )
-
-    @classmethod
-    def from_proto(cls, proto):
-        store = cls()
-        index = proto.contiguousBinIndexOffset
-        store.offset = index
-        for count in proto.contiguousBinCounts:
-            store.add(index, count)
-            index += 1
-        return store
 
 
 class CollapsingLowestDenseStore(DenseStore):

--- a/ddsketch/tests/test_ddsketch.py
+++ b/ddsketch/tests/test_ddsketch.py
@@ -33,15 +33,14 @@ from datasets import (
     UniformZoomOut,
 )
 from ddsketch.ddsketch import (
-    BaseDDSketch,
     DDSketch,
     LogCollapsingHighestDenseDDSketch,
     LogCollapsingLowestDenseDDSketch,
 )
 
-test_quantiles = [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.999, 1]
-test_sizes = [3, 5, 10, 100, 1000]
-datasets = [
+TEST_QUANTILES = [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.999, 1]
+TEST_SIZES = [3, 5, 10, 100, 1000]
+DATASETS = [
     UniformForward,
     UniformBackward,
     UniformZoomIn,
@@ -76,7 +75,7 @@ class TestDDSketches(ABC):
 
     def _evaluate_sketch_accuracy(self, sketch, data, eps, summary_stats=True):
         size = data.size
-        for quantile in test_quantiles:
+        for quantile in TEST_QUANTILES:
             sketch_q = sketch.get_quantile_value(quantile)
             data_q = data.quantile(quantile)
             err = abs(sketch_q - data_q)
@@ -88,19 +87,13 @@ class TestDDSketches(ABC):
 
     def test_distributions(self):
         """Test DDSketch on values from various distributions"""
-        for dataset in datasets:
-            for size in test_sizes:
+        for dataset in DATASETS:
+            for size in TEST_SIZES:
                 data = dataset(size)
                 sketch = self._new_dd_sketch()
                 for value in data.data:
                     sketch.add(value)
                 self._evaluate_sketch_accuracy(sketch, data, TEST_REL_ACC)
-
-                # test protobuf round trip
-                round_trip_sketch = BaseDDSketch.from_proto(sketch.to_proto())
-                self._evaluate_sketch_accuracy(
-                    round_trip_sketch, data, TEST_REL_ACC, summary_stats=False
-                )
 
     def test_add_multiple(self):
         """Test DDSketch on adding integer weighted values"""
@@ -128,7 +121,7 @@ class TestDDSketches(ABC):
     def test_merge_equal(self):
         """Test merging equal-sized DDSketches """
         parameters = [(35, 1), (1, 3), (15, 2), (40, 0.5)]
-        for size in test_sizes:
+        for size in TEST_SIZES:
             dataset = EmptyDataset(0)
             target_sketch = self._new_dd_sketch()
             for params in parameters:
@@ -146,7 +139,7 @@ class TestDDSketches(ABC):
         """Test merging variable-sized DDSketches """
         ntests = 20
         for _ in range(ntests):
-            for size in test_sizes:
+            for size in TEST_SIZES:
                 dataset = Lognormal(size)
                 sketch1 = self._new_dd_sketch()
                 sketch2 = self._new_dd_sketch()
@@ -189,7 +182,7 @@ class TestDDSketches(ABC):
         for value in dataset.data:
             sketch2.add(value)
 
-        sketch2_summary = [sketch2.get_quantile_value(q) for q in test_quantiles] + [
+        sketch2_summary = [sketch2.get_quantile_value(q) for q in TEST_QUANTILES] + [
             sketch2.sum,
             sketch2.avg,
             sketch2.num_values,
@@ -200,14 +193,14 @@ class TestDDSketches(ABC):
         for value in dataset.data:
             sketch1.add(value)
         # changes to sketch1 does not affect sketch2 after merge
-        sketch2_summary = [sketch2.get_quantile_value(q) for q in test_quantiles] + [
+        sketch2_summary = [sketch2.get_quantile_value(q) for q in TEST_QUANTILES] + [
             sketch2.sum,
             sketch2.avg,
             sketch2.num_values,
         ]
         self.assertAlmostEqual(
             sketch2_summary,
-            [sketch2.get_quantile_value(q) for q in test_quantiles]
+            [sketch2.get_quantile_value(q) for q in TEST_QUANTILES]
             + [sketch2.sum, sketch2.avg, sketch2.num_values],
         )
 
@@ -216,7 +209,7 @@ class TestDDSketches(ABC):
         # merging to an empty sketch does not change sketch2
         self.assertAlmostEqual(
             sketch2_summary,
-            [sketch2.get_quantile_value(q) for q in test_quantiles]
+            [sketch2.get_quantile_value(q) for q in TEST_QUANTILES]
             + [sketch2.sum, sketch2.avg, sketch2.num_values],
         )
 

--- a/ddsketch/tests/test_mapping.py
+++ b/ddsketch/tests/test_mapping.py
@@ -11,7 +11,6 @@ from unittest import TestCase
 
 from ddsketch.mapping import (
     CubicallyInterpolatedMapping,
-    KeyMapping,
     LogarithmicMapping,
     LinearlyInterpolatedMapping,
 )
@@ -75,21 +74,10 @@ class TestKeyMapping(ABC):
             rel_acc *= rel_acc_mult
 
     def test_offsets(self):
+        """ test offsets """
         for offset in self.offsets:
             mapping = self.mapping(0.01, offset=offset)
             self.assertEqual(mapping.key(1), int(offset))
-
-    def test_round_trip(self):
-        rel_accs = [1e-1, 1e-2, 1e-8]
-        for rel_acc in rel_accs:
-            for offset in self.offsets:
-                mapping = self.mapping(rel_acc, offset)
-                round_trip_mapping = KeyMapping.from_proto(mapping.to_proto())
-                self.assertEqual(type(mapping), type(round_trip_mapping))
-                self.assertAlmostEqual(
-                    mapping.relative_accuracy, round_trip_mapping.relative_accuracy
-                )
-                self.assertAlmostEqual(mapping.value(0), round_trip_mapping.value(0))
 
 
 class TestLogarithmicMapping(TestKeyMapping, TestCase):

--- a/ddsketch/tests/test_store.py
+++ b/ddsketch/tests/test_store.py
@@ -152,7 +152,6 @@ class TestDenseStore(TestStore, TestCase):
         for val in values:
             store.add(val)
         self._test_values(store, values)
-        self._test_values(DenseStore.from_proto(store.to_proto()), values)
 
     def _test_merging(self, list_values):
         store = DenseStore()


### PR DESCRIPTION
### What does this PR do?

Moves all the pb-specific methods to the pb directory. 

### Motivation

Users of ddsketch that don't care about protobufs won't have to install it. (Though they will have to ignore the pb directory when running tests.)


