### PR TITLE
Add mypy typing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0
       - run: pip install riot==0.8
       - run: riot -v run check_fmt
+      - run: riot -v run -s mypy
+
   test:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -94,5 +94,12 @@ Format code with
     riot run fmt
 
 
+### Type-checking
+
+Type checking is done with [mypy](http://mypy-lang.org/):
+
+    riot run mypy
+
+
 ## References
 [1] Charles Masson and Jee E Rim and Homin K. Lee. DDSketch: A fast and fully-mergeable quantile sketch with relative-error guarantees. PVLDB, 12(12): 2195-2205, 2019. (The code referenced in the paper, including our implementation of the the Greenwald-Khanna (GK) algorithm, can be found at: https://github.com/DataDog/sketches-py/releases/tag/v0.1 )

--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -34,6 +34,7 @@ DDSketch implementations are also available in:
 <a href="https://github.com/DataDog/sketches-py/">Python</a>
 <a href="https://github.com/DataDog/sketches-js/">JavaScript</a>
 """
+import typing
 
 from .exception import IllegalArgumentException
 from .exception import UnequalSketchParametersException
@@ -41,6 +42,13 @@ from .mapping import LogarithmicMapping
 from .store import CollapsingHighestDenseStore
 from .store import CollapsingLowestDenseStore
 from .store import DenseStore
+
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+
+    from .mapping import KeyMapping
+    from .store import Store
 
 
 DEFAULT_REL_ACC = 0.01  # "alpha" in the paper
@@ -73,6 +81,7 @@ class BaseDDSketch:
         negative_store,
         zero_count,
     ):
+        # type: (KeyMapping, Store, Store, float) -> None
         self.mapping = mapping
         self.store = store
         self.negative_store = negative_store
@@ -85,6 +94,7 @@ class BaseDDSketch:
         self._sum = 0.0
 
     def __repr__(self):
+        # type: () -> str
         return (
             f"store: {self.store}, negative_store: {self.negative_store}, "
             f"zero_count: {self.zero_count}, count: {self.count}, "
@@ -93,25 +103,30 @@ class BaseDDSketch:
 
     @property
     def name(self):
+        # type: () -> str
         """str: name of the sketch"""
         return "DDSketch"
 
     @property
     def num_values(self):
+        # type: () -> float
         """float: number of values in the sketch"""
         return self.count
 
     @property
     def avg(self):
+        # type: () -> float
         """float: exact avg of the values added to the sketch"""
         return self.sum / self.count
 
     @property
     def sum(self):
+        # type: () -> float
         """float: exact sum of the values added to the sketch"""
         return self._sum
 
     def add(self, val, weight=1.0):
+        # type: (float, float) -> None
         """Add a value to the sketch."""
         if weight <= 0.0:
             raise IllegalArgumentException("weight must be a positive float")
@@ -132,6 +147,7 @@ class BaseDDSketch:
             self.max = val
 
     def get_quantile_value(self, quantile):
+        # type: (float) -> Optional[float]
         """the approximate value at the specified quantile
 
         Args:
@@ -158,6 +174,7 @@ class BaseDDSketch:
         return quantile_value
 
     def merge(self, sketch):
+        # type: (BaseDDSketch) -> None
         """Merges the other sketch into this one. After this operation, this sketch
         encodes the values that were added to both this and the input sketch.
         """
@@ -187,10 +204,12 @@ class BaseDDSketch:
             self.max = sketch.max
 
     def mergeable(self, other):
+        # type: (BaseDDSketch) -> bool
         """Two sketches can be merged only if their gammas are equal."""
         return self.mapping.gamma == other.mapping.gamma
 
     def copy(self, sketch):
+        # type: (BaseDDSketch) -> None
         """copy the input sketch into this one"""
         self.store.copy(sketch.store)
         self.negative_store.copy(sketch.negative_store)
@@ -210,7 +229,7 @@ class DDSketch(BaseDDSketch):
     """
 
     def __init__(self, relative_accuracy=None):
-
+        # type: (Optional[float]) -> None
         # Make sure the parameters are valid
         if relative_accuracy is None:
             relative_accuracy = DEFAULT_REL_ACC
@@ -234,7 +253,7 @@ class LogCollapsingLowestDenseDDSketch(BaseDDSketch):
     """
 
     def __init__(self, relative_accuracy=None, bin_limit=None):
-
+        # type: (Optional[float], Optional[int]) -> None
         # Make sure the parameters are valid
         if relative_accuracy is None:
             relative_accuracy = DEFAULT_REL_ACC
@@ -264,7 +283,7 @@ class LogCollapsingHighestDenseDDSketch(BaseDDSketch):
     """
 
     def __init__(self, relative_accuracy=None, bin_limit=None):
-
+        # type: (Optional[float], Optional[int]) -> None
         # Make sure the parameters are valid
         if relative_accuracy is None:
             relative_accuracy = DEFAULT_REL_ACC

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+files = ddsketch,tests
+show_error_codes = true
+warn_return_any = true
+warn_unused_ignores = true
+warn_unused_configs = true
+no_implicit_optional = true
+ignore_missing_imports = true
+
+[mypy-ddsketch.pb.*]
+ignore_errors = true

--- a/releasenotes/notes/typing-25579ab88323a332.yaml
+++ b/releasenotes/notes/typing-25579ab88323a332.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add typing.

--- a/riotfile.py
+++ b/riotfile.py
@@ -46,5 +46,12 @@ venv = Venv(
                 ),
             ],
         ),
+        Venv(
+            name="mypy",
+            command="mypy {cmdargs}",
+            pkgs={
+                "mypy": latest,
+            },
+        ),
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="http://github.com/datadog/sketches-py",
     packages=setuptools.find_packages(),
+    package_data={"ddsketch": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
mypy type the project.

This was mostly straightforward except for a few places where there were conflicting types documented (usually int instead of float or vice versa)

There are a few type ignores too since some of the current class hierarchies cannot be typed. For example, with `Store` the `merge` method accepts a store of the same type which when typed in both the parent and child classes results in a violation of the Liskov substitution principle