### PR TITLE
Add release notes tooling

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,50 @@
+name: Changelog
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # Important that we run on `labeled` and `unlabeled` to pick up `changelog/no-changelog` being added/removed
+    # DEV: [opened, reopened, synchronize] is the default
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+jobs:
+  validate:
+    name: Validate changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # Include all history and tags
+        with:
+          fetch-depth: 0
+
+      # Ensure a new reno release note was added in this PR.
+      # Use `reno new <slug>` to add a new note to `releasenotes/notes`,
+      #   or add `changelog/no-changelog` label if no release note is needed.
+      - name: Ensure release note added
+        # Only run this on pull requests
+        if: github.event_name == 'pull_request'
+        run: scripts/check-releasenotes
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Install Dependencies
+        run: pip install reno docutils
+
+      - name: Lint changelog notes
+        run: reno lint
+
+      - name: Generate changelog
+        run: |
+          reno report | tee CHANGELOG.rst
+          rst2html.py CHANGELOG.rst CHANGELOG.html
+
+      - name: Upload CHANGELOG.rst
+        uses: actions/upload-artifact@v2
+        with:
+          name: changelog
+          path: |
+            CHANGELOG.rst
+            CHANGELOG.html

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Replace the Python version with the interpreter(s) available.
     # Run tests with Python 3.9
     riot run -p3.9 test
 
+### Release notes
+
+New features, bug fixes, deprecations and other breaking changes must have
+release notes included.
+
+To generate a release note for the change:
+
+    riot run reno new <short-description-of-change-no-spaces>
+
+Edit the generated file to include notes on the changes made in the commit/PR
+and add commit it.
+
 
 ## References
 [1] Charles Masson and Jee E Rim and Homin K. Lee. DDSketch: A fast and fully-mergeable quantile sketch with relative-error guarantees. PVLDB, 12(12): 2195-2205, 2019. (The code referenced in the paper, including our implementation of the the Greenwald-Khanna (GK) algorithm, can be found at: https://github.com/DataDog/sketches-py/releases/tag/v0.1 )

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,2 @@
+---
+unreleased_version_title: Unreleased

--- a/riotfile.py
+++ b/riotfile.py
@@ -13,5 +13,16 @@ venv = Venv(
                 "pytest": latest,
             },
         ),
+        Venv(
+            pkgs={
+                "reno": latest,
+            },
+            venvs=[
+                Venv(
+                    name="reno",
+                    command="reno {cmdargs}",
+                ),
+            ],
+        ),
     ],
 )

--- a/scripts/check-releasenotes
+++ b/scripts/check-releasenotes
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# If we are running outside a GitHub action, default to `master`
+BASE_REF="${GITHUB_BASE_REF:-master}"
+
+# Print input data
+echo "Base ref: origin/${BASE_REF}"
+echo "GitHub event path: ${GITHUB_EVENT_PATH}"
+echo "JQ: $(which jq)"
+
+
+# Skip the label check if we do not have a GitHub event path
+if [[ -f "${GITHUB_EVENT_PATH}" ]] && jq -e '.pull_request?.labels[]?.name | select(. == "no-changelog")' "${GITHUB_EVENT_PATH}";
+then
+    echo "PR has label 'no-changelog', skipping validation"
+    exit 0
+fi
+
+# Check if they added a new file to releasenotes/notes
+if git diff --name-only --diff-filter=A "origin/${BASE_REF}" | grep releasenotes/notes;
+then
+    echo "New release note found, success"
+    exit 0
+else
+    echo "Release note not found."
+    echo "Use 'reno new <slug>' to add a new note to 'releasenotes/notes', or add the label 'no-changelog' to skip this validation"
+    exit 1
+fi


### PR DESCRIPTION
Introduce tooling to use [`reno`](https://docs.openstack.org/reno) for doing release notes.

- riot commands are added to create a new release note.
- A Github workflow is added to ensure release notes are added when
  required or a Github label is added when not.
- Instructions added to the README for creating new release notes.
