### PR TITLE
Remove numpy as a dependency

### DIFF
--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -35,8 +35,6 @@ DDSketch implementations are also available in:
 <a href="https://github.com/DataDog/sketches-js/">JavaScript</a>
 """
 
-import numpy as np
-
 from .exception import IllegalArgumentException, UnequalSketchParametersException
 from .mapping import LogarithmicMapping
 from .store import CollapsingHighestDenseStore, CollapsingLowestDenseStore, DenseStore
@@ -137,10 +135,10 @@ class BaseDDSketch:
             quantile (float): 0 <= q <=1
 
         Returns:
-            the value at the specified quantile or np.NaN if the sketch is empty
+            the value at the specified quantile or None if the sketch is empty
         """
         if quantile < 0 or quantile > 1 or self.count == 0:
-            return np.NaN
+            return None
 
         rank = quantile * (self.count - 1)
         if rank < self.negative_store.count:

--- a/ddsketch/mapping.py
+++ b/ddsketch/mapping.py
@@ -97,7 +97,7 @@ class LogarithmicMapping(KeyMapping):
         return math.log2(value) * self._multiplier
 
     def _pow_gamma(self, value):
-        return math.pow(2, value / self._multiplier)
+        return 2 ** (value / self._multiplier)
 
 
 def _cbrt(x):
@@ -175,7 +175,7 @@ class CubicallyInterpolatedMapping(KeyMapping):
             - 9 * self.A * self.B * self.C
             - 27 * self.A * self.A * (value - exponent)
         )
-        cardano = _cbrt((delta_1 - math.sqrt(delta_1 * delta_1 - 4 * delta_0 * delta_0 * delta_0)) / 2)
+        cardano = _cbrt((delta_1 - ((delta_1 * delta_1 - 4 * delta_0 * delta_0 * delta_0)**.5)) / 2)
         significand_plus_one = (
             -(self.B + cardano + delta_0 / cardano) / (3 * self.A) + 1
         )

--- a/releasenotes/notes/remove-numpy-25fedcd9be9d6d80.yaml
+++ b/releasenotes/notes/remove-numpy-25fedcd9be9d6d80.yaml
@@ -1,0 +1,7 @@
+---
+prelude: >
+    numpy has been removed as a dependency.
+upgrade:
+  - |
+    ``BaseDDSketch.get_quantile_value`` will now return ``None`` instead of
+    ``numpy.NaN`` if the specified quantile is empty.

--- a/riotfile.py
+++ b/riotfile.py
@@ -11,6 +11,7 @@ venv = Venv(
             pys=["2.7", "3.6", "3.7", "3.8", "3.9"],
             pkgs={
                 "pytest": latest,
+                "numpy": latest,
             },
         ),
         Venv(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setuptools.setup(
     ],
     keywords=["ddsketch", "quantile", "sketch"],
     install_requires=[
-        "numpy>=1.11.0",
         "protobuf>=3.14.0",
     ],
     python_requires=">=3.6",

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -9,10 +9,14 @@ from abc import ABC, abstractmethod
 import math
 from unittest import TestCase
 
+import numpy
+import pytest
+
 from ddsketch.mapping import (
     CubicallyInterpolatedMapping,
     LogarithmicMapping,
     LinearlyInterpolatedMapping,
+    _cbrt,
 )
 
 
@@ -99,3 +103,8 @@ class TestCubicallyInterpolatedMapping(BaseTestKeyMapping, TestCase):
 
     def mapping(self, relative_accuracy, offset):
         return CubicallyInterpolatedMapping(relative_accuracy, offset)
+
+
+@pytest.mark.parametrize("x", [-12.3, -1.0, -1./3., 0.0, 1.0, 1./3., 2.0**10])
+def test_cbrt(x):
+    assert math.isclose(_cbrt(x), numpy.cbrt(x))


### PR DESCRIPTION
Remove numpy as a dependency of ddsketch. Use only built-in Python math functions and introduce a cuberoot utility
to replace the `numpy.cbrt` function (which somehow ends up being faster).

```
In [3]: %timeit _cbrt(-0.055605003447049994)
109 ns ± 0.226 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [4]: %timeit numpy.cbrt(-0.055605003447049994)
321 ns ± 8.41 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```