### PR TITLE
Format, add code formatting tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,17 @@ on:
       - master
   pull_request:
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: pip install riot==0.8
+      - run: riot -v run check_fmt
   test:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -87,5 +87,12 @@ Edit the generated file to include notes on the changes made in the commit/PR
 and add commit it.
 
 
+### Formatting
+
+Format code with
+
+    riot run fmt
+
+
 ## References
 [1] Charles Masson and Jee E Rim and Homin K. Lee. DDSketch: A fast and fully-mergeable quantile sketch with relative-error guarantees. PVLDB, 12(12): 2195-2205, 2019. (The code referenced in the paper, including our implementation of the the Greenwald-Khanna (GK) algorithm, can be found at: https://github.com/DataDog/sketches-py/releases/tag/v0.1 )

--- a/ddsketch/__init__.py
+++ b/ddsketch/__init__.py
@@ -1,3 +1,4 @@
 from .ddsketch import DDSketch
 
+
 __all__ = ["DDSketch"]

--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -35,9 +35,12 @@ DDSketch implementations are also available in:
 <a href="https://github.com/DataDog/sketches-js/">JavaScript</a>
 """
 
-from .exception import IllegalArgumentException, UnequalSketchParametersException
+from .exception import IllegalArgumentException
+from .exception import UnequalSketchParametersException
 from .mapping import LogarithmicMapping
-from .store import CollapsingHighestDenseStore, CollapsingLowestDenseStore, DenseStore
+from .store import CollapsingHighestDenseStore
+from .store import CollapsingLowestDenseStore
+from .store import DenseStore
 
 
 DEFAULT_REL_ACC = 0.01  # "alpha" in the paper

--- a/ddsketch/mapping.py
+++ b/ddsketch/mapping.py
@@ -16,7 +16,8 @@ the LogarithmicMapping, but it requires the costly evaluation of the logarithm
 when computing the index. Other mappings can approximate the logarithmic
 mapping, while being less computationally costly.
 """
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 import math
 import sys
 
@@ -52,17 +53,17 @@ class KeyMapping(ABC):
 
     @classmethod
     def from_gamma_offset(cls, gamma, offset):
-        """ Constructor used by pb.proto """
+        """Constructor used by pb.proto"""
         relative_accuracy = (gamma - 1.0) / (gamma + 1.0)
         return cls(relative_accuracy, offset=offset)
 
     @abstractmethod
     def _log_gamma(self, value):
-        """ Return (an approximation of) the logarithm of the value base gamma """
+        """Return (an approximation of) the logarithm of the value base gamma"""
 
     @abstractmethod
     def _pow_gamma(self, value):
-        """ Return (an approximation of) gamma to the power value """
+        """Return (an approximation of) gamma to the power value"""
 
     def key(self, value):
         """
@@ -102,7 +103,7 @@ class LogarithmicMapping(KeyMapping):
 
 def _cbrt(x):
     # type: (float) -> float
-    y = abs(x)**(1./3.)
+    y = abs(x) ** (1.0 / 3.0)
     if x < 0:
         return -y
     return y
@@ -127,7 +128,7 @@ class LinearlyInterpolatedMapping(KeyMapping):
         return significand + (exponent - 1)
 
     def _exp2_approx(self, value):
-        """ inverse of _log2_approx """
+        """inverse of _log2_approx"""
         exponent = math.floor(value) + 1
         mantissa = (value - exponent + 2) / 2.0
         return math.ldexp(mantissa, exponent)
@@ -158,7 +159,7 @@ class CubicallyInterpolatedMapping(KeyMapping):
         self._multiplier /= self.C
 
     def _cubic_log2_approx(self, value):
-        """ approximates log2 using a cubic polynomial """
+        """approximates log2 using a cubic polynomial"""
         mantissa, exponent = math.frexp(value)
         significand = 2 * mantissa - 1
         return (
@@ -166,7 +167,7 @@ class CubicallyInterpolatedMapping(KeyMapping):
         ) * significand + (exponent - 1)
 
     def _cubic_exp2_approx(self, value):
-        """ Derived from Cardano's formula """
+        """Derived from Cardano's formula"""
 
         exponent = math.floor(value)
         delta_0 = self.B * self.B - 3 * self.A * self.C
@@ -175,7 +176,10 @@ class CubicallyInterpolatedMapping(KeyMapping):
             - 9 * self.A * self.B * self.C
             - 27 * self.A * self.A * (value - exponent)
         )
-        cardano = _cbrt((delta_1 - ((delta_1 * delta_1 - 4 * delta_0 * delta_0 * delta_0)**.5)) / 2)
+        cardano = _cbrt(
+            (delta_1 - ((delta_1 * delta_1 - 4 * delta_0 * delta_0 * delta_0) ** 0.5))
+            / 2
+        )
         significand_plus_one = (
             -(self.B + cardano + delta_0 / cardano) / (3 * self.A) + 1
         )

--- a/ddsketch/store.py
+++ b/ddsketch/store.py
@@ -7,7 +7,8 @@
 We start with 128 bins and grow the store in chunks of 128 unless specified
 otherwise."""
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 import math
 
 
@@ -167,7 +168,7 @@ class DenseStore(Store):
         self.offset -= shift
 
     def _center_bins(self, new_min_key, new_max_key):
-        """ center the bins; this changes the offset"""
+        """center the bins; this changes the offset"""
         middle_key = new_min_key + (new_max_key - new_min_key + 1) // 2
         self._shift_bins(self.offset + self.length() // 2 - middle_key)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.isort]
+force_single_line = true
+lines_after_imports = 2
+force_sort_within_sections = true
+known_first_party = "ddsketch"
+default_section = "THIRDPARTY"
+skip = [".riot/", ".venv/", "ddsketch/pb"]
+line_length = 120
+
+[tool.black]
+exclude = '''
+(
+  /(
+    \.riot
+  | ddsketch/pb.*
+  | \.venv.*
+  | \.eggs
+  )/
+)
+'''

--- a/riotfile.py
+++ b/riotfile.py
@@ -22,6 +22,27 @@ venv = Venv(
                 Venv(
                     name="reno",
                     command="reno {cmdargs}",
+                )
+            ],
+        ),
+        Venv(
+            pkgs={
+                "black": "==21.7b0",
+                "isort": latest,
+                "toml": latest,
+            },
+            venvs=[
+                Venv(
+                    name="black",
+                    command="black {cmdargs}",
+                ),
+                Venv(
+                    name="fmt",
+                    command="isort . && black .",
+                ),
+                Venv(
+                    name="check_fmt",
+                    command="isort --check . && black --check .",
                 ),
             ],
         ),

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import setuptools
 
+
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 

--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -3,7 +3,9 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2020 Datadog, Inc.
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC
+from abc import abstractmethod
+from abc import abstractproperty
 
 import numpy as np
 

--- a/tests/test_ddsketch.py
+++ b/tests/test_ddsketch.py
@@ -5,38 +5,36 @@
 
 """Tests for DDSketch"""
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 from collections import Counter
 from unittest import TestCase
 
 import numpy as np
 
-from tests.datasets import (
-    Bimodal,
-    Constant,
-    EmptyDataset,
-    Exponential,
-    Integers,
-    Lognormal,
-    Laplace,
-    Mixed,
-    NegativeUniformBackward,
-    NegativeUniformForward,
-    NumberLineBackward,
-    NumberLineForward,
-    Normal,
-    Trimodal,
-    UniformBackward,
-    UniformForward,
-    UniformSqrt,
-    UniformZoomIn,
-    UniformZoomOut,
-)
-from ddsketch.ddsketch import (
-    DDSketch,
-    LogCollapsingHighestDenseDDSketch,
-    LogCollapsingLowestDenseDDSketch,
-)
+from ddsketch.ddsketch import DDSketch
+from ddsketch.ddsketch import LogCollapsingHighestDenseDDSketch
+from ddsketch.ddsketch import LogCollapsingLowestDenseDDSketch
+from tests.datasets import Bimodal
+from tests.datasets import Constant
+from tests.datasets import EmptyDataset
+from tests.datasets import Exponential
+from tests.datasets import Integers
+from tests.datasets import Laplace
+from tests.datasets import Lognormal
+from tests.datasets import Mixed
+from tests.datasets import NegativeUniformBackward
+from tests.datasets import NegativeUniformForward
+from tests.datasets import Normal
+from tests.datasets import NumberLineBackward
+from tests.datasets import NumberLineForward
+from tests.datasets import Trimodal
+from tests.datasets import UniformBackward
+from tests.datasets import UniformForward
+from tests.datasets import UniformSqrt
+from tests.datasets import UniformZoomIn
+from tests.datasets import UniformZoomOut
+
 
 TEST_QUANTILES = [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.999, 1]
 TEST_SIZES = [3, 5, 10, 100, 1000]
@@ -71,7 +69,7 @@ class BaseTestDDSketches(ABC):
     @staticmethod
     @abstractmethod
     def _new_dd_sketch():
-        """ create a new DDSketch of the appropriate type """
+        """create a new DDSketch of the appropriate type"""
 
     def _evaluate_sketch_accuracy(self, sketch, data, eps, summary_stats=True):
         size = data.size
@@ -119,7 +117,7 @@ class BaseTestDDSketches(ABC):
         self.assertAlmostEqual(sketch.avg, 74.75)
 
     def test_merge_equal(self):
-        """Test merging equal-sized DDSketches """
+        """Test merging equal-sized DDSketches"""
         parameters = [(35, 1), (1, 3), (15, 2), (40, 0.5)]
         for size in TEST_SIZES:
             dataset = EmptyDataset(0)
@@ -136,7 +134,7 @@ class BaseTestDDSketches(ABC):
             self._evaluate_sketch_accuracy(target_sketch, dataset, TEST_REL_ACC)
 
     def test_merge_unequal(self):
-        """Test merging variable-sized DDSketches """
+        """Test merging variable-sized DDSketches"""
         ntests = 20
         for _ in range(ntests):
             for size in TEST_SIZES:

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -5,23 +5,22 @@
 
 """Tests for the KeyMapping classes"""
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 import math
 from unittest import TestCase
 
 import numpy
 import pytest
 
-from ddsketch.mapping import (
-    CubicallyInterpolatedMapping,
-    LogarithmicMapping,
-    LinearlyInterpolatedMapping,
-    _cbrt,
-)
+from ddsketch.mapping import CubicallyInterpolatedMapping
+from ddsketch.mapping import LinearlyInterpolatedMapping
+from ddsketch.mapping import LogarithmicMapping
+from ddsketch.mapping import _cbrt
 
 
 def _relative_error(expected_min, expected_max, actual):
-    """ helper method to calculate the relative error """
+    """helper method to calculate the relative error"""
     if expected_min < 0 or expected_max < 0 or actual < 0:
         raise Exception()
     if (expected_min <= actual) and (actual <= expected_max):
@@ -35,7 +34,7 @@ def _relative_error(expected_min, expected_max, actual):
 
 
 def _test_value_rel_acc(mapping, tester):
-    """ calculate the relative accuracy of a mapping on a large range of values """
+    """calculate the relative accuracy of a mapping on a large range of values"""
     value_mult = 2 - math.sqrt(2) * 1e-1
     max_relative_acc = 0.0
     value = mapping.min_possible
@@ -63,10 +62,10 @@ class BaseTestKeyMapping(ABC):
 
     @abstractmethod
     def mapping(self, relative_accuracy, offset):
-        """ return the KeyMapping instance to be tested """
+        """return the KeyMapping instance to be tested"""
 
     def test_accuracy(self):
-        """ test the mapping on a large range of relative accuracies """
+        """test the mapping on a large range of relative accuracies"""
         rel_acc_mult = 1 - math.sqrt(2) * 1e-1
         min_rel_acc = 1e-8
         rel_acc = 1 - 1e-3
@@ -78,7 +77,7 @@ class BaseTestKeyMapping(ABC):
             rel_acc *= rel_acc_mult
 
     def test_offsets(self):
-        """ test offsets """
+        """test offsets"""
         for offset in self.offsets:
             mapping = self.mapping(0.01, offset=offset)
             self.assertEqual(mapping.key(1), int(offset))
@@ -105,6 +104,6 @@ class TestCubicallyInterpolatedMapping(BaseTestKeyMapping, TestCase):
         return CubicallyInterpolatedMapping(relative_accuracy, offset)
 
 
-@pytest.mark.parametrize("x", [-12.3, -1.0, -1./3., 0.0, 1.0, 1./3., 2.0**10])
+@pytest.mark.parametrize("x", [-12.3, -1.0, -1.0 / 3.0, 0.0, 1.0, 1.0 / 3.0, 2.0 ** 10])
 def test_cbrt(x):
     assert math.isclose(_cbrt(x), numpy.cbrt(x))

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -1,12 +1,12 @@
 from abc import ABC
 from unittest import TestCase
 
-from ddsketch.mapping import (
-    CubicallyInterpolatedMapping,
-    LogarithmicMapping,
-    LinearlyInterpolatedMapping,
-)
-from ddsketch.pb.proto import DDSketchProto, KeyMappingProto, StoreProto
+from ddsketch.mapping import CubicallyInterpolatedMapping
+from ddsketch.mapping import LinearlyInterpolatedMapping
+from ddsketch.mapping import LogarithmicMapping
+from ddsketch.pb.proto import DDSketchProto
+from ddsketch.pb.proto import KeyMappingProto
+from ddsketch.pb.proto import StoreProto
 from ddsketch.store import DenseStore
 from tests.test_ddsketch import TestDDSketch
 from tests.test_store import TestDenseStore

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -5,16 +5,16 @@
 
 """Tests for the Store classes"""
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 from collections import Counter
 import sys
 from unittest import TestCase
 
-from ddsketch.store import (
-    CollapsingHighestDenseStore,
-    CollapsingLowestDenseStore,
-    DenseStore,
-)
+from ddsketch.store import CollapsingHighestDenseStore
+from ddsketch.store import CollapsingLowestDenseStore
+from ddsketch.store import DenseStore
+
 
 TEST_BIN_LIMIT = [1, 20, 1000]
 EXTREME_MAX = sys.maxsize


### PR DESCRIPTION
Introduce riot command for formatting code using [`black`](https://black.readthedocs.io/en/stable/) and [`isort`](https://github.com/PyCQA/isort).

Instructions are added to the README as well.