### PR TITLE
Add Python 2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: pip install riot==0.8
+      - run: pip install riot==0.9.0
       - run: riot -v run check_fmt
       - run: riot -v run -s mypy
       - run: riot -v run -s flake8
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +32,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install riot
-        run: pip install riot==0.9.0
+        # Note that pip3 has to be used since the system pip when running
+        # under the 2.7 instance will be Python 2 pip.
+        # (riot is not Python 2 compatible)
+        run: pip3 install riot==0.9.0
       - run: |
           riot run -p ${{ matrix.python-version}} test

--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -55,7 +55,7 @@ DEFAULT_REL_ACC = 0.01  # "alpha" in the paper
 DEFAULT_BIN_LIMIT = 2048
 
 
-class BaseDDSketch:
+class BaseDDSketch(object):
     """The base implementation of DDSketch with neither mapping nor storage specified.
 
     Args:
@@ -96,9 +96,17 @@ class BaseDDSketch:
     def __repr__(self):
         # type: () -> str
         return (
-            f"store: {self.store}, negative_store: {self.negative_store}, "
-            f"zero_count: {self.zero_count}, count: {self.count}, "
-            f"sum: {self.sum}, min: {self.min}, max: {self.max}"
+            "store: {}, negative_store: {}, "
+            "zero_count: {}, count: {}, "
+            "sum: {}, min: {}, max: {}"
+        ).format(
+            self.store,
+            self.negative_store,
+            self.zero_count,
+            self.count,
+            self.sum,
+            self.min,
+            self.max,
         )
 
     @property
@@ -237,7 +245,7 @@ class DDSketch(BaseDDSketch):
         mapping = LogarithmicMapping(relative_accuracy)
         store = DenseStore()
         negative_store = DenseStore()
-        super().__init__(
+        super(DDSketch, self).__init__(
             mapping=mapping,
             store=store,
             negative_store=negative_store,
@@ -267,7 +275,7 @@ class LogCollapsingLowestDenseDDSketch(BaseDDSketch):
         mapping = LogarithmicMapping(relative_accuracy)
         store = CollapsingLowestDenseStore(bin_limit)
         negative_store = CollapsingLowestDenseStore(bin_limit)
-        super().__init__(
+        super(LogCollapsingLowestDenseDDSketch, self).__init__(
             mapping=mapping,
             store=store,
             negative_store=negative_store,
@@ -297,7 +305,7 @@ class LogCollapsingHighestDenseDDSketch(BaseDDSketch):
         mapping = LogarithmicMapping(relative_accuracy)
         store = CollapsingHighestDenseStore(bin_limit)
         negative_store = CollapsingHighestDenseStore(bin_limit)
-        super().__init__(
+        super(LogCollapsingHighestDenseDDSketch, self).__init__(
             mapping=mapping,
             store=store,
             negative_store=negative_store,

--- a/releasenotes/notes/py2-c963608396db7258.yaml
+++ b/releasenotes/notes/py2-c963608396db7258.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for Python 2.

--- a/riotfile.py
+++ b/riotfile.py
@@ -63,8 +63,10 @@ venv = Venv(
         Venv(
             name="mypy",
             command="mypy {cmdargs}",
+            create=True,
             pkgs={
                 "mypy": latest,
+                "types-six": latest,
             },
         ),
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
@@ -22,7 +22,9 @@ setuptools.setup(
     keywords=["ddsketch", "quantile", "sketch"],
     install_requires=[
         "protobuf>=3.14.0",
+        "six",
+        "typing; python_version<'3.5'",
     ],
-    python_requires=">=3.6",
+    python_requires=">=2.7",
     download_url="https://github.com/DataDog/sketches-py/archive/v1.0.tar.gz",
 )

--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -3,14 +3,13 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2020 Datadog, Inc.
 
-from abc import ABC
-from abc import abstractmethod
-from abc import abstractproperty
+import abc
 
 import numpy as np
+import six
 
 
-class Dataset(ABC):
+class Dataset(six.with_metaclass(abc.ABCMeta)):
     def __init__(self, size):
         self.size = int(size)
         self.data = self.populate()
@@ -41,11 +40,11 @@ class Dataset(ABC):
     def avg(self):
         return np.mean(self.data)
 
-    @abstractproperty
+    @abc.abstractmethod
     def name(self):
         """Name of dataset"""
 
-    @abstractmethod
+    @abc.abstractmethod
     def populate(self):
         """Populate self.data with self.size values"""
 

--- a/tests/test_ddsketch.py
+++ b/tests/test_ddsketch.py
@@ -5,12 +5,12 @@
 
 """Tests for DDSketch"""
 
-from abc import ABC
-from abc import abstractmethod
+import abc
 from collections import Counter
 from unittest import TestCase
 
 import numpy as np
+import six
 
 from ddsketch.ddsketch import DDSketch
 from ddsketch.ddsketch import LogCollapsingHighestDenseDDSketch
@@ -63,11 +63,11 @@ TEST_REL_ACC = 0.05
 TEST_BIN_LIMIT = 1024
 
 
-class BaseTestDDSketches(ABC):
+class BaseTestDDSketches(six.with_metaclass(abc.ABCMeta)):
     """AbstractBaseClass for testing DDSketch implementations"""
 
     @staticmethod
-    @abstractmethod
+    @abc.abstractmethod
     def _new_dd_sketch():
         """Create a new DDSketch of the appropriate type"""
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -5,13 +5,13 @@
 
 """Tests for the KeyMapping classes"""
 
-from abc import ABC
-from abc import abstractmethod
+import abc
 import math
 from unittest import TestCase
 
 import numpy
 import pytest
+import six
 
 from ddsketch.mapping import CubicallyInterpolatedMapping
 from ddsketch.mapping import LinearlyInterpolatedMapping
@@ -55,12 +55,12 @@ def _test_value_rel_acc(mapping, tester):
     return max_relative_acc
 
 
-class BaseTestKeyMapping(ABC):
+class BaseTestKeyMapping(six.with_metaclass(abc.ABCMeta)):
     """Abstract class for testing KeyMapping classes"""
 
     offsets = [0, 1, -12.23, 7768.3]
 
-    @abstractmethod
+    @abc.abstractmethod
     def mapping(self, relative_accuracy, offset):
         """Return the KeyMapping instance to be tested"""
 
@@ -106,4 +106,4 @@ class TestCubicallyInterpolatedMapping(BaseTestKeyMapping, TestCase):
 
 @pytest.mark.parametrize("x", [-12.3, -1.0, -1.0 / 3.0, 0.0, 1.0, 1.0 / 3.0, 2.0 ** 10])
 def test_cbrt(x):
-    assert math.isclose(_cbrt(x), numpy.cbrt(x))
+    assert pytest.approx(_cbrt(x), numpy.cbrt(x))

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -1,5 +1,7 @@
-from abc import ABC
+import abc
 from unittest import TestCase
+
+import six
 
 from ddsketch.mapping import CubicallyInterpolatedMapping
 from ddsketch.mapping import LinearlyInterpolatedMapping
@@ -12,7 +14,7 @@ from tests.test_ddsketch import TestDDSketch
 from tests.test_store import TestDenseStore
 
 
-class BaseTestKeyMappingProto(ABC):
+class BaseTestKeyMappingProto(six.with_metaclass(abc.ABCMeta)):
     offsets = [0, 1, -12.23, 7768.3]
 
     def test_round_trip(self):
@@ -62,7 +64,9 @@ class TestStoreProto(TestDenseStore, TestCase):
 class TestDDSketchProto(TestDDSketch, TestCase):
     def _evaluate_sketch_accuracy(self, sketch, data, eps, summary_stats=False):
         round_trip_sketch = DDSketchProto.from_proto(DDSketchProto.to_proto(sketch))
-        super()._evaluate_sketch_accuracy(round_trip_sketch, data, eps, summary_stats)
+        super(TestDDSketchProto, self)._evaluate_sketch_accuracy(
+            round_trip_sketch, data, eps, summary_stats
+        )
 
     def test_add_multiple(self):
         """Override."""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -5,11 +5,12 @@
 
 """Tests for the Store classes"""
 
-from abc import ABC
-from abc import abstractmethod
+import abc
 from collections import Counter
 import sys
 from unittest import TestCase
+
+import six
 
 from ddsketch.store import CollapsingHighestDenseStore
 from ddsketch.store import CollapsingLowestDenseStore
@@ -21,18 +22,18 @@ EXTREME_MAX = sys.maxsize
 EXTREME_MIN = -sys.maxsize - 1
 
 
-class BaseTestStore(ABC):
+class BaseTestStore(six.with_metaclass(abc.ABCMeta)):
     """Base class for testing Store classes"""
 
-    @abstractmethod
+    @abc.abstractmethod
     def _test_values(self, store, values):
         """Test the store's bin counts against what we expect"""
 
-    @abstractmethod
+    @abc.abstractmethod
     def _test_store(self, values):
         """Initialize the store; add the values; call _test_values"""
 
-    @abstractmethod
+    @abc.abstractmethod
     def _test_merging(self, list_values):
         """
         Initialize the stores; for each values in list_values, add them to the


### PR DESCRIPTION
Add support for Python 2.


The motivation for adding support for (EOL) Python 2 is that a lot of the world has not yet upgraded and usage in the APM library (https://github.com/datadog/dd-trace-py) is desired.

This was mostly straightforward except for some really subtle int/float division gotchas.