### PR TITLE
Add development container

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,12 @@ The quantiles of `values` concatenated with `other_values` are still accurate to
 
 ## Development
 
-To work on ddsketch a Python interpreter must be installed. It is recommended
-to create and use a virtualenv for the tooling:
+To work on ddsketch a Python interpreter must be installed. It is recommended to use the provided development
+container (requires [docker](https://www.docker.com/)) which includes all the required Python interpreters.
+
+    docker-compose run dev
+
+Or, if developing outside of docker then it is recommended to use a virtual environment:
 
     pip install virtualenv
     virtualenv --python=3 .venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  dev:
+    # The dd-trace-py image includes all required versions of Python.
+    image: datadog/dd-trace-py:buster
+    command: bash
+    network_mode: host
+    working_dir: /src
+    volumes:
+      - ./:/src


### PR DESCRIPTION
Since the project supports many versions of Python, it's unlikely that a
developer will have them all installed.

To avoid having to use CI to test we can use the dd-trace-py docker
image which includes all the required CPython interpeters.