### PR TITLE
Internalize DDSketch implementation

### DIFF
--- a/ddsketch/pb/proto.py
+++ b/ddsketch/pb/proto.py
@@ -73,10 +73,10 @@ class DDSketchProto:
     def to_proto(self, ddsketch):
         """serialize to protobuf"""
         return pb.DDSketch(
-            mapping=KeyMappingProto.to_proto(ddsketch.mapping),
-            positiveValues=StoreProto.to_proto(ddsketch.store),
-            negativeValues=StoreProto.to_proto(ddsketch.negative_store),
-            zeroCount=ddsketch.zero_count,
+            mapping=KeyMappingProto.to_proto(ddsketch._mapping),
+            positiveValues=StoreProto.to_proto(ddsketch._store),
+            negativeValues=StoreProto.to_proto(ddsketch._negative_store),
+            zeroCount=ddsketch._zero_count,
         )
 
     @classmethod

--- a/releasenotes/notes/ddsketch-api-a84ffc0875bbacd6.yaml
+++ b/releasenotes/notes/ddsketch-api-a84ffc0875bbacd6.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - "``DDSketch`` attributes ``mapping``, ``store``, ``negative_store``, ``zero_count``, ``relative_accuracy``, ``min`` and ``max`` have been removed."
+  - "``DDSketch.copy`` method has been removed."
+  - "``DDSketch.count`` attribute has been made read-only."
+  - "``DDSketch.mergeable`` method has been removed."


### PR DESCRIPTION
There are attributes and methods on DDSketch that are needlessly public.
Internalizing them makes maintenance easier.


Depends on #38 