### PR TITLE
Add build/deploy workflow

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,0 +1,70 @@
+name: Build
+
+on:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheel:
+    name: Build wheels
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+        # Include all history and tags
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Build wheels
+        run: |
+          pip install wheel
+          pip wheel --no-deps -w dist .
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # Include all history and tags
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Build sdist
+        run: |
+          python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheel, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Copy the script used by dd-trace-py/riot which builds wheels and releases them to PyPI when a Github release is published.
