### PR TITLE
Add automated versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *~
 .riot/
 
+# Generated version module
+ddsketch/__version.py
+
 # Ignore files generated during `python setup.py install`
 build/
 dist/

--- a/ddsketch/__init__.py
+++ b/ddsketch/__init__.py
@@ -1,4 +1,8 @@
+from ._version import get_version
 from .ddsketch import DDSketch
+
+
+__version__ = get_version()
 
 
 __all__ = ["DDSketch"]

--- a/ddsketch/_version.py
+++ b/ddsketch/_version.py
@@ -1,0 +1,17 @@
+def get_version():
+    # type: () -> str
+    """Return the package version.
+
+    The write_to functionality of setuptools_scm is used (see setup.py)
+    to output the version to ddsketch/__version.py which we attempt to import.
+
+    This is done to avoid the expensive overhead of importing pkg_resources.
+    """
+    try:
+        from .__version import version
+
+        return version
+    except ImportError:
+        import pkg_resources
+
+        return pkg_resources.get_distribution(__name__).version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,13 @@ line_length = 120
 
 [tool.black]
 exclude = '''
-(
-  /(
+^/(
+  (
     \.riot
   | ddsketch/pb.*
   | \.venv.*
   | \.eggs
   )/
+  | ddsketch/__version.py
 )
 '''

--- a/releasenotes/notes/version-b2a276df190a703a.yaml
+++ b/releasenotes/notes/version-b2a276df190a703a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The package version is now exposed through ``ddsketch.__version__``.

--- a/riotfile.py
+++ b/riotfile.py
@@ -67,6 +67,7 @@ venv = Venv(
             pkgs={
                 "mypy": latest,
                 "types-six": latest,
+                "types-setuptools": latest,
             },
         ),
     ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ddsketch",
-    version="1.1.2",
     author="Jee Rim, Charles-Philippe Masson, Homin Lee",
     author_email="jee.rim@datadoghq.com, charles.masson@datadoghq.com, homin@datadoghq.com",
     description="Distributed quantile sketches",
@@ -27,4 +26,6 @@ setuptools.setup(
     ],
     python_requires=">=2.7",
     download_url="https://github.com/DataDog/sketches-py/archive/v1.0.tar.gz",
+    setup_requires=["setuptools_scm"],
+    use_scm_version={"write_to": "ddsketch/__version.py"},
 )

--- a/tests/test_ddsketch.py
+++ b/tests/test_ddsketch.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 import numpy as np
 import six
 
+import ddsketch
 from ddsketch.ddsketch import DDSketch
 from ddsketch.ddsketch import LogCollapsingHighestDenseDDSketch
 from ddsketch.ddsketch import LogCollapsingLowestDenseDDSketch
@@ -234,3 +235,9 @@ class TestLogCollapsingHighestDenseDDSketch(BaseTestDDSketches, TestCase):
     @staticmethod
     def _new_dd_sketch():
         return LogCollapsingHighestDenseDDSketch(TEST_REL_ACC, TEST_BIN_LIMIT)
+
+
+def test_version():
+    """Ensure the package version is exposed by the API."""
+    assert hasattr(ddsketch, "__version__")
+    assert isinstance(ddsketch.__version__, str)


### PR DESCRIPTION
Use [setuptools_scm](https://github.com/pypa/setuptools_scm/) to
autogenerate the version of the package.

The version is exposed in the public api through `ddsketch.__version__`.