### PR TITLE
Add public classes to top level module

### DIFF
--- a/ddsketch/__init__.py
+++ b/ddsketch/__init__.py
@@ -1,8 +1,24 @@
 from ._version import get_version
 from .ddsketch import DDSketch
+from .ddsketch import LogCollapsingHighestDenseDDSketch
+from .ddsketch import LogCollapsingLowestDenseDDSketch
+from .mapping import CubicallyInterpolatedMapping
+from .mapping import LinearlyInterpolatedMapping
+from .mapping import LogarithmicMapping
+from .store import CollapsingHighestDenseStore
+from .store import CollapsingLowestDenseStore
 
 
 __version__ = get_version()
 
 
-__all__ = ["DDSketch"]
+__all__ = [
+    "DDSketch",
+    "LogCollapsingLowestDenseDDSketch",
+    "LogCollapsingHighestDenseDDSketch",
+    "CubicallyInterpolatedMapping",
+    "LinearlyInterpolatedMapping",
+    "LogarithmicMapping",
+    "CollapsingHighestDenseStore",
+    "CollapsingLowestDenseStore",
+]

--- a/releasenotes/notes/toplevelapi-6c04f2ca35a49d4b.yaml
+++ b/releasenotes/notes/toplevelapi-6c04f2ca35a49d4b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The implementations of stores and mappings are now exposed via the top
+    level module ``ddsketch``.


### PR DESCRIPTION
These classes are part of the public API so making them easier to access
would go a long way for users. It also simplifies the API so users don't
need to know that there is a `ddsketch.store` module, for instance.