### PR TITLE
Fix mypy Any return

### DIFF
--- a/ddsketch/mapping.py
+++ b/ddsketch/mapping.py
@@ -110,7 +110,7 @@ class LogarithmicMapping(KeyMapping):
 
     def _pow_gamma(self, value):
         # type: (float) -> float
-        return 2 ** (value / self._multiplier)
+        return math.pow(2.0, value / self._multiplier)
 
 
 def _cbrt(x):

--- a/riotfile.py
+++ b/riotfile.py
@@ -79,6 +79,9 @@ venv = Venv(
             command="mypy --install-types --non-interactive {cmdargs}",
             pkgs={
                 "mypy": latest,
+                "types-protobuf": latest,
+                "types-setuptools": latest,
+                "types-six": latest,
             },
         ),
     ],


### PR DESCRIPTION
For some reason (https://github.com/python/mypy/issues/7765) `**` has a
return type of `Any` so just use `math.pow()` instead.