### PR TITLE
Pin protobuf version

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -16,13 +16,13 @@ venv = Venv(
                 Venv(
                     pys=["2.7", "3.6", "3.7", "3.8", "3.9"],
                     pkgs={
-                        "protobuf": ["==3.0.0", latest],
+                        "protobuf": ["==3.0.0", "<3.19", latest],
                     },
                 ),
                 Venv(
                     pys=["3.10"],
                     pkgs={
-                        "protobuf": ["==3.8.0", latest],
+                        "protobuf": ["==3.8.0", "<3.19", latest],
                     },
                 ),
             ],


### PR DESCRIPTION
The latest version of protobuf doesn't declare python_version
and so it breaks on Python < 3.7.