### PR TITLE
Fix merging stores with max_key=0

### DIFF
--- a/ddsketch/store.py
+++ b/ddsketch/store.py
@@ -182,7 +182,8 @@ class DenseStore(Store):
     def _extend_range(self, key, second_key=None):
         # type: (int, Optional[int]) -> None
         """Grow the bins as necessary and call _adjust"""
-        second_key = second_key or key
+        if second_key is None:
+            second_key = key
         new_min_key = min(key, second_key, self.min_key)
         new_max_key = max(key, second_key, self.max_key)
 

--- a/releasenotes/notes/extend-range-06474632c8235187.yaml
+++ b/releasenotes/notes/extend-range-06474632c8235187.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix merging stores with max_key=0.


### PR DESCRIPTION
Since 0 is falsy, the condition would set second_key to the value of key
when 0 was passed.

Fixes #57 