### PR TITLE
Add testing support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/riotfile.py
+++ b/riotfile.py
@@ -30,7 +30,7 @@ venv = Venv(
                     },
                 ),
                 Venv(
-                    pys=["3.10"],
+                    pys=["3.10", "3.11"],
                     pkgs={
                         "protobuf": ["==3.8.0", "<3.19.0", latest],
                     },


### PR DESCRIPTION
Python 3.11 was released Oct 24: https://www.python.org/downloads/release/python-3110/

Add testing support for it.