### PR TITLE
make protobuf an optional requirement

### DIFF
--- a/releasenotes/notes/pbopt-ec6525c1948d782f.yaml
+++ b/releasenotes/notes/pbopt-ec6525c1948d782f.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    This change makes protobuf an optional requirement. It can be installed with ``pip install ddsketch[serialization]``.

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,15 @@ setuptools.setup(
     ],
     keywords=["ddsketch", "quantile", "sketch"],
     install_requires=[
-        "protobuf>=3.0.0; python_version>='3.7'",
-        "protobuf>=3.0.0,<4.21.0; python_version<'3.7'",
         "six",
         "typing; python_version<'3.5'",
     ],
+    extras_require={
+        "serialization": [
+            "protobuf>=3.0.0; python_version>='3.7'",
+            "protobuf>=3.0.0,<4.21.0; python_version<'3.7'",
+        ]
+    },
     python_requires=">=2.7",
     download_url="https://github.com/DataDog/sketches-py/archive/v1.0.tar.gz",
     setup_requires=["setuptools_scm"],

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,7 @@ setuptools.setup(
     install_requires=[
         "six",
     ],
-    extras_require={
-        "serialization": [
-            "protobuf>=3.0.0"
-        ]
-    },
+    extras_require={"serialization": ["protobuf>=3.0.0"]},
     python_requires=">=3.7",
     download_url="https://github.com/DataDog/sketches-py/archive/v1.0.tar.gz",
     setup_requires=["setuptools_scm"],

--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -218,7 +218,6 @@ class UniformSqrt(Dataset):
 
 
 class Constant(Dataset):
-
     constant = 42.0
 
     @property
@@ -230,7 +229,6 @@ class Constant(Dataset):
 
 
 class Exponential(Dataset):
-
     scale = 0.01
 
     @classmethod
@@ -247,7 +245,6 @@ class Exponential(Dataset):
 
 
 class Lognormal(Dataset):
-
     scale = 100.0
 
     @classmethod
@@ -264,7 +261,6 @@ class Lognormal(Dataset):
 
 
 class Normal(Dataset):
-
     loc = 37.4
     scale = 1.0
 
@@ -283,7 +279,6 @@ class Normal(Dataset):
 
 
 class Laplace(Dataset):
-
     loc = 11278.0
     scale = 100.0
 
@@ -302,7 +297,6 @@ class Laplace(Dataset):
 
 
 class Bimodal(Dataset):
-
     right_loc = 17.3
     left_loc = -2.0
     left_std = 3.0
@@ -322,7 +316,6 @@ class Bimodal(Dataset):
 
 
 class Mixed(Dataset):
-
     mean = 0.0
     sigma = 0.25
     scale_factor = 0.1
@@ -351,7 +344,6 @@ class Mixed(Dataset):
 
 
 class Trimodal(Dataset):
-
     right_loc = 17.3
     left_loc = 5.0
     left_std = 0.5
@@ -374,7 +366,6 @@ class Trimodal(Dataset):
 
 
 class Integers(Dataset):
-
     loc = 4.3
     scale = 5.0
 


### PR DESCRIPTION
### What does this PR do?

Makes protobuf not install by default, instead putting it under the "serialization" install feature

### Motivation

ddtracepy can't depend on protobuf anymore. see https://github.com/DataDog/dd-trace-py/pull/8797 for details.

