### PR TITLE
drop support for python older than 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
-      - uses: actions/checkout@v2
+          python-version: '3.12'
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: pip install riot==0.9.0
+      - run: pip install riot==0.19.0
       - run: riot -v run check_fmt
       - run: riot -v run -s mypy
       - run: riot -v run -s flake8
@@ -23,18 +23,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: install riot
         # Note that pip3 has to be used since the system pip when running
         # under the 2.7 instance will be Python 2 pip.
         # (riot is not Python 2 compatible)
-        run: pip3 install riot==0.9.0
+        run: pip3 install riot==0.19.0
       - run: |
           riot run -p ${{ matrix.python-version}} test

--- a/ddsketch/ddsketch.py
+++ b/ddsketch/ddsketch.py
@@ -43,10 +43,10 @@ from .store import DenseStore
 
 
 if typing.TYPE_CHECKING:
-    from typing import Optional
+    from typing import Optional  # noqa: F401
 
-    from .mapping import KeyMapping
-    from .store import Store
+    from .mapping import KeyMapping  # noqa: F401
+    from .store import Store  # noqa: F401
 
 
 DEFAULT_REL_ACC = 0.01  # "alpha" in the paper

--- a/ddsketch/store.py
+++ b/ddsketch/store.py
@@ -18,8 +18,8 @@ import typing
 
 
 if typing.TYPE_CHECKING:
-    from typing import List
-    from typing import Optional
+    from typing import List  # noqa: F401
+    from typing import Optional  # noqa: F401
 
 import six
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ lines_after_imports = 2
 force_sort_within_sections = true
 known_first_party = "ddsketch"
 default_section = "THIRDPARTY"
-skip = [".riot/", ".venv/", "ddsketch/pb"]
+skip = [".riot/", ".venv/", "ddsketch/pb", "ddsketch/__version.py"]
 line_length = 120
 
 [tool.black]

--- a/releasenotes/notes/oldpy-db6189c9b26e10f7.yaml
+++ b/releasenotes/notes/oldpy-db6189c9b26e10f7.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    This release drops support for Python versions older than 3.7.

--- a/riotfile.py
+++ b/riotfile.py
@@ -46,7 +46,6 @@ venv = Venv(
                 "flake8-blind-except": latest,
                 "flake8-builtins": latest,
                 "flake8-docstrings": latest,
-                "flake8-logging-format": latest,
                 "flake8-rst-docstrings": latest,
                 # needed for some features from flake8-rst-docstrings
                 "pygments": latest,

--- a/riotfile.py
+++ b/riotfile.py
@@ -14,25 +14,15 @@ venv = Venv(
             },
             venvs=[
                 Venv(
-                    pys=["2.7", "3.6"],
-                    pkgs={
-                        "protobuf": [
-                            "==3.0.0",
-                            "<3.19",
-                            "!=4.21.0",
-                        ],  # not latest due to https://github.com/protocolbuffers/protobuf/issues/10053
-                    },
-                ),
-                Venv(
                     pys=["3.7", "3.8", "3.9"],
                     pkgs={
-                        "protobuf": ["==3.0.0", "<3.19", latest],
+                        "protobuf": ["==3.0.0", latest],
                     },
                 ),
                 Venv(
-                    pys=["3.10"],
+                    pys=["3.10", "3.11", "3.12"],
                     pkgs={
-                        "protobuf": ["==3.8.0", "<3.19.0", latest],
+                        "protobuf": ["==3.8.0", latest],
                     },
                 ),
             ],

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,9 @@ setuptools.setup(
     keywords=["ddsketch", "quantile", "sketch"],
     install_requires=[
         "protobuf>=3.0.0; python_version>='3.7'",
-        "protobuf>=3.0.0,<4.21.0; python_version<'3.7'",
         "six",
-        "typing; python_version<'3.5'",
     ],
-    python_requires=">=2.7",
+    python_requires=">=3.7",
     download_url="https://github.com/DataDog/sketches-py/archive/v1.0.tar.gz",
     setup_requires=["setuptools_scm"],
     use_scm_version={"write_to": "ddsketch/__version.py"},

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -26,7 +26,7 @@ class BaseTestKeyMappingProto(six.with_metaclass(abc.ABCMeta)):
                 round_trip_mapping = KeyMappingProto.from_proto(
                     KeyMappingProto.to_proto(mapping)
                 )
-                assert type(mapping) == type(round_trip_mapping)
+                assert type(mapping) == type(round_trip_mapping)  # noqa: E721
                 assert mapping.relative_accuracy == pytest.approx(
                     round_trip_mapping.relative_accuracy
                 )


### PR DESCRIPTION
### What does this PR do?

Drops support for Python versions older than 3.7

### Motivation

The CI jobs that try to use older Python versions don't work anymore.
