### PR TITLE
Bump the build_deploy Ubuntu version

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_wheel:
     name: Build wheels
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
18.04 is no longer supported by Github actions.