### PR TITLE
Add nix devenv and package library through flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ ddsketch/__version.py
 build/
 dist/
 *.egg-info/
+
+.venv/
+
+# Ignore nix build result
+/result

--- a/ddsketch/_version.py
+++ b/ddsketch/_version.py
@@ -1,3 +1,6 @@
+from pkg_resources import DistributionNotFound
+
+
 def get_version():
     # type: () -> str
     """Return the package version.
@@ -14,4 +17,7 @@ def get_version():
     except ImportError:
         import pkg_resources
 
-        return pkg_resources.get_distribution(__name__).version
+        try:
+            return pkg_resources.get_distribution(__name__).version
+        except DistributionNotFound:
+            return "0+unknown"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1719690277,
+        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1719887753,
+        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,89 @@
+{
+  description = "ddsketch-py";
+  nixConfig.bash-prompt-prefix = "\[ddsketch-py\] ";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    nixpkgs.url = "github:NixOS/nixpkgs/24.05";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      treefmt-nix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        python = pkgs.python312;
+
+        pythonDevEnv = python;
+
+        treefmt = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+
+        finalPkg = python.pkgs.buildPythonPackage rec {
+          name = "ddsketch";
+          version = "3.0.1";
+          src = ./.;
+
+          propagatedBuildInputs = with python.pkgs; [
+            six
+            protobuf
+	    setuptools
+          ];
+          nativeBuildInputs = with python.pkgs; [ setuptools_scm ];
+          checkInputs = with python.pkgs; [
+            pytest
+            numpy
+          ];
+          env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+          pythonImportsCheck = [ "ddsketch" ];
+
+          postPatch = ''
+            patchShebangs setup.py
+            echo version=\"${version}\" > ddsketch/__version.py
+          '';
+        };
+
+        devEnv = pkgs.buildEnv {
+          name = "root";
+          paths = [ pkgs.bashInteractive ];
+          pathsToLink = [ "/bin" ];
+        };
+      in
+      {
+        packages = {
+          python = python;
+        };
+
+        packages.default = finalPkg;
+        formatter = treefmt.config.build.wrapper;
+
+        checks = {
+          python = finalPkg;
+        };
+
+        devShells.default = pkgs.mkShell {
+          venvDir = "./.venv";
+          nativeBuildInputs = [
+            finalPkg.nativeBuildInputs
+            python.pkgs.venvShellHook
+            python.pkgs.six
+            python.pkgs.protobuf
+            python.pkgs.numpy
+          ];
+          propagatedBuildInputs = [ treefmt.config.build.wrapper ];
+          packages = [
+            python.pkgs.pytest
+            treefmt.config.build.wrapper
+          ];
+        };
+      }
+    );
+}

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,11 @@
+# treefmt.nix
+{ pkgs, ... }:
+{
+  # Used to find the project root
+  projectRootFile = "flake.nix";
+  # Enable the Nix formatter 
+  programs.nixfmt.enable = true;
+  # Enable the Python formatter
+  programs.black.enable = true;
+  settings.formatter.black.excludes = [ "ddsketch/pb/*" ];
+}


### PR DESCRIPTION
Added nix so that:
https://github.com/DataDog/dd-apm-test-agent

can directly import this package via nix too.

use `nix develop` to setup local dev env
run tests `nix flake tests`

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
