### PR TITLE
ci: migrate to PyPI trusted publishing

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -57,14 +57,13 @@ jobs:
     needs: [build_wheel, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
+    environment: secure_publish_environment
     steps:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0


### PR DESCRIPTION
### What does this PR do?

Migrate away from token based publishing to trusted publishing.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
